### PR TITLE
Fix CI by removing dependency on unreachable git:// package

### DIFF
--- a/test/QueryEngineSparqlEndpoint-test.ts
+++ b/test/QueryEngineSparqlEndpoint-test.ts
@@ -50,6 +50,7 @@ describe('QueryEngineSparqlEndpoint', () => {
   }
 }`),
         headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
+        ok: true,
         status: 200,
       }),
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,13 @@
   dependencies:
     "@types/rdf-js" "^2.0.1"
 
+"@rdfjs/types@^1.0.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.2.tgz#9c2f9848c44c26d383bed2a808571de3b93b808d"
+  integrity sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==
+  dependencies:
+    "@types/node" "*"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -1676,20 +1683,20 @@ fb-watchman@^2.0.0:
     bser "^2.0.0"
 
 fetch-sparql-endpoint@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.4.0.tgz#a4c80e2fb7ec42c9a7eb01905de8a699a7d77ff7"
-  integrity sha512-RBu3fmK8fpExr5JpJfr3/NpOYcelhWtmEogADjwRWcT8T6CiMb1vpz7y3GDmuBUXShM5xzOyYy6qsyDsCsADFg==
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.6.2.tgz#d9f8173ec4dc738ff0322410500b8666ef3aeb6b"
+  integrity sha512-d0nTwXc6BBnQdrmx7+Bk6pLJ5MLzJtYJRNq4YSpL4Bym8hd12RaBUL7OkcxtuFaMY9gG2Mw0JVNMZeF3bjVSBg==
   dependencies:
-    is-stream "^1.1.0"
+    is-stream "^2.0.0"
     isomorphic-fetch "^2.2.1"
     minimist "^1.2.0"
     n3 "^1.0.0"
-    node-web-streams "^0.2.2"
     rdf-string "^1.3.1"
-    sparqljs "^2.0.3"
+    sparqljs "^3.0.0"
     sparqljson-parse "^1.5.0"
     sparqlxml-parse "^1.2.0"
     stream-to-string "^1.1.0"
+    web-streams-node "^0.4.0"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -3161,14 +3168,6 @@ node-notifier@^7.0.0:
     uuid "^7.0.3"
     which "^2.0.2"
 
-node-web-streams@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/node-web-streams/-/node-web-streams-0.2.2.tgz#087e76bbeb7e8dc56686b25db4e60c5ff9db091f"
-  integrity sha1-CH52u+t+jcVmhrJdtOYMX/nbCR8=
-  dependencies:
-    is-stream "^1.1.0"
-    web-streams-polyfill "git://github.com/gwicke/web-streams-polyfill#spec_performance_improvements"
-
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -3516,6 +3515,13 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
+rdf-data-factory@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz#11b39e0c80e51bca83828b2ddaa686f733be966f"
+  integrity sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==
+  dependencies:
+    "@rdfjs/types" "^1.0.0"
+
 rdf-literal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rdf-literal/-/rdf-literal-1.0.0.tgz#7324935eacfead859d08423d9b20a2d2e1afb9b8"
@@ -3571,6 +3577,11 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+readable-stream-node-to-web@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz#8b7614faa1465ebfa0da9b9ca6303fa27073b7cf"
+  integrity sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==
 
 readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.6"
@@ -3979,10 +3990,17 @@ sparqlalgebrajs@^2.2.2:
     rdf-string "^1.3.1"
     sparqljs "^3.0.1"
 
-sparqljs@^2.0.3, sparqljs@^2.2.1:
+sparqljs@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-2.2.3.tgz#6eb7f5f69b27b99d3b646e89271c048bd61d9293"
   integrity sha512-lrzSQadbkiQk4O6RjXJjec/EevVIsnAfbNK3t8XJtocogNojfQM7KC/UttyRTAq4IOXa0vRVoFTRapcbgFVRWg==
+
+sparqljs@^3.0.0:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.4.tgz#d1f0c525aab6030c521b12ccef7efa2f57c82e90"
+  integrity sha512-hb4C84gf7KM7vz+iG595mPwvqxOvBJCm9L3dCxtV2zZDht6ZMmMG0tHeeqFeqwb9875yU9U4lhYe4LYRvWj0BQ==
+  dependencies:
+    rdf-data-factory "^1.1.2"
 
 sparqljs@^3.0.1:
   version "3.0.1"
@@ -4543,9 +4561,19 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-"web-streams-polyfill@git://github.com/gwicke/web-streams-polyfill#spec_performance_improvements":
-  version "1.2.2"
-  resolved "git://github.com/gwicke/web-streams-polyfill#42c488428adea1dc0c0245014e4896ad456b1ded"
+web-streams-node@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/web-streams-node/-/web-streams-node-0.4.0.tgz#641e42d7a7c4df95785a774e2484ba93d36fd672"
+  integrity sha512-u+PBQs8DFaBrN/bxCLFn21tO/ZP7EM3qA4FGzppoUCcZ5CaMbKOsN8uOp27ylVEsfrxcR2tsF6gWHI5M8bN73w==
+  dependencies:
+    is-stream "^1.1.0"
+    readable-stream-node-to-web "^1.0.1"
+    web-streams-ponyfill "^1.4.1"
+
+web-streams-ponyfill@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz#0ae863cc5f7493903679f16b08cbf14d432b62f4"
+  integrity sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## The failure

Every CI job on every branch has been failing, and none of them reach the build or test step — they all die during `yarn install`:

```
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/gwicke/web-streams-polyfill
fatal: unable to connect to github.com: errno=Connection timed out
```

## Root cause

`yarn.lock` pinned `fetch-sparql-endpoint` to **1.4.0**, which depends on `node-web-streams`, which resolves `web-streams-polyfill` from a **`git://`** URL:

```
node-web-streams@^0.2.2:
  dependencies:
    web-streams-polyfill "git://github.com/gwicke/web-streams-polyfill#spec_performance_improvements"
```

GitHub [permanently disabled the unencrypted `git://` protocol in January 2022](https://github.blog/2021-09-01-improving-git-protocol-security-github/), so that fetch can only ever time out. This is not flakiness — the install cannot succeed until the dependency is gone. It reproduces locally on a clean checkout of `master`.

## Fix

`fetch-sparql-endpoint` dropped `node-web-streams` in **1.5.0** in favour of the registry-hosted `web-streams-node`. Re-resolving the lockfile entry to **1.6.2** removes the unreachable dependency.

This stays inside the existing `^1.4.0` range, so `package.json` is unchanged, and the lockfile edit was kept surgical — only that entry was re-resolved, so no unrelated transitive versions move. In particular, `@types/node` stays pinned at 12.x; letting it float to a current release pulls in `.d.ts` syntax that TypeScript 4.0 cannot parse.

One test change comes with it. Since 1.5.0, `fetchRawStream` checks `httpResponse.ok` rather than `httpResponse.status`. The test's hand-rolled `Response` mock only set `status: 200`, so under 1.6.2 it was read as a failed response. A real `Response` sets `ok` for any 2xx status, so the mock now sets it too — this fills a gap in the mock rather than relaxing the assertion.

## Verification

Run on a clean checkout with `node_modules` removed, matching what CI does:

| Step | Result |
| --- | --- |
| `yarn install` | passes (no `git://` entries remain in the lockfile) |
| `yarn run build` | passes |
| `yarn run lint` | passes |
| `yarn run test` | 1/1 passing, 100% coverage |

The lockfile is stable — a second `yarn install` leaves it byte-identical.

## Out of scope

This gets `master` green again. It does **not** address the separate failure visible in the open Renovate PRs, where `tsc` cannot parse modern dependency type definitions:

```
node_modules/@types/n3/index.d.ts(192,47): error TS1110: Type expected.
node_modules/fetch-sparql-endpoint/lib/SparqlEndpointFetcher.d.ts(5,15): error TS1005: ',' expected.
```

That is a toolchain-age problem — TypeScript 4.0 and `ts-jest`/`jest` 26 are too old for the current type ecosystem (`ts-jest` already warns that TypeScript 4.0.2 is untested against it). Unblocking those PRs means upgrading TypeScript and the Jest stack together, which is a larger change and deliberately left out of this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtEk4vEXY3oHtpRdfNQ3pB)_